### PR TITLE
Number of free slots updated as soon as Course is reserved

### DIFF
--- a/frontend/src/stores/courses.js
+++ b/frontend/src/stores/courses.js
@@ -157,6 +157,7 @@ class courseStore {
                 });
                 this.rootStore.userStore.setBalance(course.price);
                 reservation.bookingStatus = 1;
+                await this.fetchCourses();
                 this.rootStore.userStore.reservedCourses.push(reservation);
                 // @TODO: handle failure states: Error messages, etc
             }


### PR DESCRIPTION
eg. When we book a course, and the "number of seats" available is "3 vaapana". Once the course is booked and if you go back to see the details (without reloading the page), the "number of seats" are still "3 vaapana" instead of "2 vaapana".

This PR fixes this issue.