### PR TITLE
Change design for MainModal button when there is not enough balance

### DIFF
--- a/frontend/src/scene/main-view/CourseModal.js
+++ b/frontend/src/scene/main-view/CourseModal.js
@@ -252,7 +252,11 @@ const MainModal = ({
                                 </Button>
                             ) : (
                                 course.reasons[0] === 'resource' && (
-                                    <Button onClick={onAddSaldo}>
+                                    <Button
+                                        alternative
+                                        bold
+                                        onClick={onAddSaldo}
+                                    >
                                         {content.balanceView.topUp}
                                     </Button>
                                 )


### PR DESCRIPTION
Keep the MainModal button design consistent for all cases: when a user is logged in and has enough balance, when a user is logged in and doesn't have enough balance, when a user is not logged in

![image](https://user-images.githubusercontent.com/37651584/55230288-06564f80-5228-11e9-96b0-e3269db002a0.png)
